### PR TITLE
feat: scaffold dashboard layout with tailwind and routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+.env

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sedna-dashboard-v1",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "react-router-dom": "^6.22.3",
+    "framer-motion": "^10.16.4",
+    "lucide-react": "^0.294.0",
+    "classnames": "^2.3.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Sedna Dashboard</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,7 @@
+import AppRoutes from './routes/AppRoutes';
+
+function App() {
+  return <AppRoutes />;
+}
+
+export default App;

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="currentColor">
+  <circle cx="50" cy="50" r="40" />
+</svg>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,18 @@
+import ThemeToggle from './ThemeToggle';
+import logo from '../assets/logo.svg';
+
+export default function Header() {
+  return (
+    <header className="w-full flex items-center justify-between px-4 py-2 bg-[#20252a] text-white">
+      <div className="flex items-center space-x-2">
+        <img src={logo} alt="logo" className="h-8 w-8" />
+        <span className="font-bold">Sedna</span>
+      </div>
+      <div className="flex items-center space-x-3">
+        <button className="px-3 py-1 rounded bg-main hover:bg-blue-700">Support</button>
+        <button className="px-3 py-1 rounded bg-secondary hover:bg-orange-600">Logout</button>
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -1,0 +1,17 @@
+import { NavLink } from 'react-router-dom';
+
+export default function NavButton({ to, icon: Icon, label, collapsed }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `flex items-center px-4 py-2 my-1 rounded text-gray-200 hover:bg-gray-700 ${
+          isActive ? 'bg-gray-700' : ''
+        }`
+      }
+    >
+      <Icon className="w-5 h-5" />
+      {!collapsed && <span className="ml-3 whitespace-nowrap">{label}</span>}
+    </NavLink>
+  );
+}

--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion';
+
+export default function PageContainer({ children }) {
+  return (
+    <motion.main
+      className="flex-1 p-6 bg-gray-100 dark:bg-gray-900"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{ duration: 0.2 }}
+    >
+      {children}
+    </motion.main>
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Menu, MapPin, Activity, DollarSign, FileText } from 'lucide-react';
+import NavButton from './NavButton';
+
+const navItems = [
+  { to: '/equipment-location', icon: MapPin, label: 'Equipment Location' },
+  { to: '/equipment-status', icon: Activity, label: 'Equipment Status' },
+  { to: '/finance', icon: DollarSign, label: 'Finance' },
+  { to: '/log-details', icon: FileText, label: 'Log Details' },
+];
+
+export default function Sidebar() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <motion.aside
+      animate={{ width: collapsed ? 72 : 240 }}
+      className="h-screen bg-[#2e353b] text-white flex flex-col"
+    >
+      <button
+        className="p-4 focus:outline-none"
+        onClick={() => setCollapsed((prev) => !prev)}
+      >
+        <Menu />
+      </button>
+      <nav className="flex-1 px-2">
+        {navItems.map((item) => (
+          <NavButton key={item.to} {...item} collapsed={collapsed} />
+        ))}
+      </nav>
+    </motion.aside>
+  );
+}

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,16 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../context/ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="w-5 h-5 text-yellow-400" /> : <Moon className="w-5 h-5" />}
+    </button>
+  );
+}

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+import { ThemeProvider } from './context/ThemeContext';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -1,0 +1,15 @@
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import { Outlet } from 'react-router-dom';
+
+export default function DashboardLayout() {
+  return (
+    <div className="flex h-screen overflow-hidden bg-white dark:bg-gray-800">
+      <Sidebar />
+      <div className="flex flex-col flex-1">
+        <Header />
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/EquipmentLocation.jsx
+++ b/src/pages/EquipmentLocation.jsx
@@ -1,0 +1,9 @@
+import PageContainer from '../components/PageContainer';
+
+export default function EquipmentLocation() {
+  return (
+    <PageContainer>
+      <h1 className="text-2xl font-semibold">Equipment Location</h1>
+    </PageContainer>
+  );
+}

--- a/src/pages/EquipmentStatus.jsx
+++ b/src/pages/EquipmentStatus.jsx
@@ -1,0 +1,9 @@
+import PageContainer from '../components/PageContainer';
+
+export default function EquipmentStatus() {
+  return (
+    <PageContainer>
+      <h1 className="text-2xl font-semibold">Equipment Status</h1>
+    </PageContainer>
+  );
+}

--- a/src/pages/Finance.jsx
+++ b/src/pages/Finance.jsx
@@ -1,0 +1,9 @@
+import PageContainer from '../components/PageContainer';
+
+export default function Finance() {
+  return (
+    <PageContainer>
+      <h1 className="text-2xl font-semibold">Finance</h1>
+    </PageContainer>
+  );
+}

--- a/src/pages/LogDetails.jsx
+++ b/src/pages/LogDetails.jsx
@@ -1,0 +1,9 @@
+import PageContainer from '../components/PageContainer';
+
+export default function LogDetails() {
+  return (
+    <PageContainer>
+      <h1 className="text-2xl font-semibold">Log Details</h1>
+    </PageContainer>
+  );
+}

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,0 +1,20 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import DashboardLayout from '../layouts/DashboardLayout';
+import EquipmentLocation from '../pages/EquipmentLocation';
+import EquipmentStatus from '../pages/EquipmentStatus';
+import Finance from '../pages/Finance';
+import LogDetails from '../pages/LogDetails';
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<DashboardLayout />}>
+        <Route index element={<Navigate to="/equipment-location" />} />
+        <Route path="equipment-location" element={<EquipmentLocation />} />
+        <Route path="equipment-status" element={<EquipmentStatus />} />
+        <Route path="finance" element={<Finance />} />
+        <Route path="log-details" element={<LogDetails />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        main: '#036EC8',
+        secondary: '#e16f3d',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- scaffold CRA-style React app with Tailwind CSS and dark/light theme context
- add header, collapsible sidebar with navigation, and page container
- wire up routing for equipment, finance, and logs pages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947251ca3c83319d50c955d0e34b77