### PR TITLE
Redesign dashboard layout and theming

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,16 +1,16 @@
 import ThemeToggle from './ThemeToggle';
-import logo from '../assets/logo.svg';
+import logo from '../assets/sedna_logo.png';
 
 export default function Header() {
   return (
-    <header className="w-full flex items-center justify-between px-4 py-2 bg-[#20252a] text-white">
+    <header className="w-full flex items-center justify-between px-4 py-2 bg-white dark:bg-[#20252a] text-gray-900 dark:text-white shadow">
       <div className="flex items-center space-x-2">
         <img src={logo} alt="logo" className="h-8 w-8" />
         <span className="font-bold">Sedna</span>
       </div>
       <div className="flex items-center space-x-3">
-        <button className="px-3 py-1 rounded bg-main hover:bg-blue-700">Support</button>
-        <button className="px-3 py-1 rounded bg-secondary hover:bg-orange-600">Logout</button>
+        <button className="px-3 py-1 rounded bg-main text-white hover:bg-blue-700">Support</button>
+        <button className="px-3 py-1 rounded bg-red-500 text-white hover:bg-red-600">Logout</button>
         <ThemeToggle />
       </div>
     </header>

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -5,8 +5,8 @@ export default function NavButton({ to, icon: Icon, label, collapsed }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center px-4 py-2 my-1 rounded text-gray-200 hover:bg-gray-700 ${
-          isActive ? 'bg-gray-700' : ''
+        `flex items-center px-4 py-2 my-1 rounded text-gray-800 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 ${
+          isActive ? 'bg-gray-200 dark:bg-gray-700' : ''
         }`
       }
     >

--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 export default function PageContainer({ children }) {
   return (
     <motion.main
-      className="flex-1 p-6 bg-gray-100 dark:bg-gray-900"
+      className="flex-1 p-6 bg-gradient-light dark:bg-gradient-dark"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -16,7 +16,7 @@ export default function Sidebar() {
   return (
     <motion.aside
       animate={{ width: collapsed ? 72 : 240 }}
-      className="h-screen bg-[#2e353b] text-white flex flex-col"
+      className="h-full bg-gray-100 text-gray-900 dark:bg-[#2e353b] dark:text-white flex flex-col"
     >
       <button
         className="p-4 focus:outline-none"

--- a/src/index.css
+++ b/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+  @apply bg-gradient-light dark:bg-gradient-dark text-gray-900 dark:text-gray-100;
 }

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -4,11 +4,13 @@ import { Outlet } from 'react-router-dom';
 
 export default function DashboardLayout() {
   return (
-    <div className="flex h-screen overflow-hidden bg-white dark:bg-gray-800">
-      <Sidebar />
-      <div className="flex flex-col flex-1">
-        <Header />
-        <Outlet />
+    <div className="flex flex-col h-screen overflow-hidden">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar />
+        <div className="flex-1 overflow-auto">
+          <Outlet />
+        </div>
       </div>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ module.exports = {
         main: '#036EC8',
         secondary: '#e16f3d',
       },
+      backgroundImage: {
+        'gradient-light': 'linear-gradient(to bottom right, #ffffff, #f7f9fc, #e8eef5)',
+        'gradient-dark': 'radial-gradient(circle at top left, #036EC8 5%, #2e353b 30%, #1a1d20 100%)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- Replace header logo with `sedna_logo.png` and give logout a red tone
- Stretch header full-width, move sidebar below, and make navigation theme-aware
- Introduce light/dark gradient backgrounds via Tailwind extensions

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894768cede88331bd60b47e768d261e