### PR TITLE
Refine dashboard theming and navigation

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,9 +4,8 @@ import logo from '../assets/sedna_logo.png';
 export default function Header() {
   return (
     <header className="w-full flex items-center justify-between px-4 py-2 bg-white dark:bg-[#20252a] text-gray-900 dark:text-white shadow">
-      <div className="flex items-center space-x-2">
-        <img src={logo} alt="logo" className="h-8 w-8" />
-        <span className="font-bold">Sedna</span>
+      <div className="flex items-center">
+        <img src={logo} alt="Sedna logo" className="h-8 w-auto" />
       </div>
       <div className="flex items-center space-x-3">
         <button className="px-3 py-1 rounded bg-main text-white hover:bg-blue-700">Support</button>

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -5,7 +5,7 @@ export default function NavButton({ to, icon: Icon, label, collapsed }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center px-4 py-2 my-1 rounded text-gray-800 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 ${
+        `flex items-center px-4 py-2 my-1 rounded text-gray-800 dark:text-gray-200 hover:text-secondary hover:bg-gray-200 dark:hover:bg-gray-700 ${
           isActive ? 'bg-gray-200 dark:bg-gray-700' : ''
         }`
       }

--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -3,11 +3,11 @@ import { motion } from 'framer-motion';
 export default function PageContainer({ children }) {
   return (
     <motion.main
-      className="flex-1 p-6 bg-gradient-light dark:bg-gradient-dark"
+      className="flex-1 p-6"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
-      transition={{ duration: 0.2 }}
+      transition={{ duration: 0.5, ease: 'easeInOut' }}
     >
       {children}
     </motion.main>

--- a/src/index.css
+++ b/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gradient-light dark:bg-gradient-dark text-gray-900 dark:text-gray-100;
+  @apply min-h-screen bg-white dark:bg-[#1a1d20] bg-gradient-light dark:bg-gradient-dark text-gray-900 dark:text-gray-100;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,10 @@ module.exports = {
         secondary: '#e16f3d',
       },
       backgroundImage: {
-        'gradient-light': 'linear-gradient(to bottom right, #ffffff, #f7f9fc, #e8eef5)',
-        'gradient-dark': 'radial-gradient(circle at top left, #036EC8 5%, #2e353b 30%, #1a1d20 100%)',
+        'gradient-light':
+          'radial-gradient(circle at top left, #036EC8 0%, #f7f9fc 50%, #ffffff 100%)',
+        'gradient-dark':
+          'radial-gradient(circle at top left, #036EC8 0%, #2e353b 50%, #1a1d20 100%)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Replace dashboard gradients with full-page radial blends in both themes and add color fallbacks
- Slow page transition animations and enhance sidebar hover styling with brand accent
- Clean header branding by showing only the logo

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68947a43fad88331a9aa67cf71868f49