### PR TITLE
Add glassmorphism panels to equipment location page

### DIFF
--- a/src/pages/EquipmentLocation.jsx
+++ b/src/pages/EquipmentLocation.jsx
@@ -1,9 +1,22 @@
 import PageContainer from '../components/PageContainer';
 
 export default function EquipmentLocation() {
+  const panelClasses =
+    "p-4 backdrop-blur-md bg-white/5 border border-white/10 rounded-xl shadow-md text-white";
+
   return (
     <PageContainer>
-      <h1 className="text-2xl font-semibold">Equipment Location</h1>
+      <h1 className="text-2xl font-semibold mb-6">Equipment Location</h1>
+      <div className="flex gap-4 h-[500px]">
+        <div className={`w-1/3 ${panelClasses}`}>Panel 1</div>
+        <div className="flex flex-col gap-4 flex-1">
+          <div className={`flex-1 ${panelClasses}`}>Panel 2</div>
+          <div className="flex gap-4 flex-1">
+            <div className={`flex-1 ${panelClasses}`}>Panel 3</div>
+            <div className={`flex-1 ${panelClasses}`}>Panel 4</div>
+          </div>
+        </div>
+      </div>
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- style EquipmentLocation page with four glassmorphism panels for layout testing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68947cbe27748331b9404e903f849ad8