### PR TITLE
Add equipment status panels and sidebar hover styling

### DIFF
--- a/src/api/equipmentStatusData.json
+++ b/src/api/equipmentStatusData.json
@@ -1,0 +1,21 @@
+{
+  "uptime": [
+    {"time": "Mon", "value": 98},
+    {"time": "Tue", "value": 96},
+    {"time": "Wed", "value": 97},
+    {"time": "Thu", "value": 93},
+    {"time": "Fri", "value": 95}
+  ],
+  "output": [
+    {"label": "Pump A", "value": 80},
+    {"label": "Pump B", "value": 60},
+    {"label": "Pump C", "value": 90},
+    {"label": "Pump D", "value": 70}
+  ],
+  "statuses": [
+    {"equipment": "Pump A", "status": "Online", "temp": 68},
+    {"equipment": "Pump B", "status": "Maintenance", "temp": null},
+    {"equipment": "Pump C", "status": "Online", "temp": 72},
+    {"equipment": "Pump D", "status": "Offline", "temp": null}
+  ]
+}

--- a/src/components/NavButton.jsx
+++ b/src/components/NavButton.jsx
@@ -5,13 +5,15 @@ export default function NavButton({ to, icon: Icon, label, collapsed }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center px-4 py-2 my-1 rounded text-gray-800 dark:text-gray-200 hover:text-secondary hover:bg-gray-200 dark:hover:bg-gray-700 ${
+        `group flex items-center px-4 py-2 my-1 rounded transition-colors text-gray-800 dark:text-gray-200 hover:text-secondary hover:bg-gray-200 dark:hover:bg-gray-700 ${
           isActive ? 'bg-gray-200 dark:bg-gray-700' : ''
         }`
       }
     >
-      <Icon className="w-5 h-5" />
-      {!collapsed && <span className="ml-3 whitespace-nowrap">{label}</span>}
+      <Icon className="w-5 h-5 transition-colors group-hover:text-secondary" />
+      {!collapsed && (
+        <span className="ml-3 whitespace-nowrap transition-colors group-hover:text-secondary">{label}</span>
+      )}
     </NavLink>
   );
 }

--- a/src/pages/EquipmentStatus.jsx
+++ b/src/pages/EquipmentStatus.jsx
@@ -1,9 +1,138 @@
 import PageContainer from '../components/PageContainer';
+import data from '../api/equipmentStatusData.json';
+
+const panelClasses =
+  "p-4 backdrop-blur-md bg-white/5 border border-white/10 rounded-xl shadow-md text-gray-900 dark:text-white";
+
+function LineChart({ data }) {
+  const width = 300;
+  const height = 120;
+  const maxVal = Math.max(...data.map((d) => d.value));
+  const points = data
+    .map((d, i) => `${(i / (data.length - 1)) * width},${height - (d.value / maxVal) * height}`)
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-full">
+      <polyline
+        fill="none"
+        strokeWidth="2"
+        stroke="currentColor"
+        points={points}
+        className="text-main"
+      />
+    </svg>
+  );
+}
+
+function BarChart({ data }) {
+  const width = 300;
+  const height = 120;
+  const maxVal = Math.max(...data.map((d) => d.value));
+  const barWidth = width / data.length;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-full">
+      {data.map((d, i) => (
+        <rect
+          key={d.label}
+          x={i * barWidth + barWidth * 0.1}
+          y={height - (d.value / maxVal) * height}
+          width={barWidth * 0.8}
+          height={(d.value / maxVal) * height}
+          className="fill-main"
+        />
+      ))}
+    </svg>
+  );
+}
+
+function StatusTable({ data }) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left">
+          <th className="py-1">Equipment</th>
+          <th className="py-1">Status</th>
+          <th className="py-1">Temp (°C)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row) => (
+          <tr key={row.equipment} className="odd:bg-white/5">
+            <td className="py-1">{row.equipment}</td>
+            <td className="py-1">{row.status}</td>
+            <td className="py-1">{row.temp ?? '--'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function StatusDistribution({ data }) {
+  const counts = data.reduce((acc, cur) => {
+    acc[cur.status] = (acc[cur.status] || 0) + 1;
+    return acc;
+  }, {});
+  const entries = Object.entries(counts);
+  const width = 300;
+  const height = 120;
+  const maxVal = Math.max(...entries.map((e) => e[1]));
+  const barWidth = width / entries.length;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-full">
+      {entries.map(([status, count], i) => (
+        <g key={status}>
+          <rect
+            x={i * barWidth + barWidth * 0.1}
+            y={height - (count / maxVal) * height}
+            width={barWidth * 0.8}
+            height={(count / maxVal) * height}
+            className="fill-secondary"
+          />
+          <text
+            x={i * barWidth + barWidth / 2}
+            y={height - 4}
+            textAnchor="middle"
+            className="text-xs fill-current"
+          >
+            {status}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
 
 export default function EquipmentStatus() {
   return (
     <PageContainer>
-      <h1 className="text-2xl font-semibold">Equipment Status</h1>
+      <h1 className="text-2xl font-semibold mb-6">Equipment Status</h1>
+      <div className="flex gap-4 h-[500px]">
+        <div className={`w-1/3 ${panelClasses}`}>
+          <h2 className="mb-2 font-medium">Weekly Uptime %</h2>
+          <LineChart data={data.uptime} />
+        </div>
+        <div className="flex flex-col gap-4 flex-1">
+          <div className={`flex-1 ${panelClasses}`}>
+            <h2 className="mb-2 font-medium">Output by Equipment</h2>
+            <BarChart data={data.output} />
+          </div>
+          <div className="flex gap-4 flex-1">
+            <div className={`flex-1 ${panelClasses}`}>
+              <h2 className="mb-2 font-medium">Current Status</h2>
+              <StatusTable data={data.statuses} />
+            </div>
+            <div className={`flex-1 ${panelClasses}`}>
+              <h2 className="mb-2 font-medium">Status Distribution</h2>
+              <StatusDistribution data={data.statuses} />
+            </div>
+          </div>
+        </div>
+      </div>
     </PageContainer>
   );
 }
+


### PR DESCRIPTION
## Summary
- add Equipment Status dashboard panels with sample charts and table
- show navigation icon and label in secondary color on hover

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689480798610833195064fdc39323164